### PR TITLE
#1, #5, Fix blocking deferred, Add alternate wrapper class name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ parts/
 sdist/
 var/
 *.egg-info/
+MANIFEST
 .installed.cfg
 *.egg
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ target/
 
 # Git
 *.orig
+.idea

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include txcelery/*.py
-include test/*.py
-include README.md

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ txCelery
 
 Celery for Twisted:  manage Celery tasks from twisted using the Deferred API
 
-[![PyPI version](https://badge.fury.io/py/txCelery.svg)](http://badge.fury.io/py/txCelery)
+[![PyPI version](https://badge.fury.io/py/txcelery-py3.svg)](http://badge.fury.io/py/txcelery-py3)
 
 ##Deprecation Notice
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-txCelery
+txCelery-py3
 =============
 
 Celery for Twisted:  manage Celery tasks from twisted using the Deferred API
 
 [![PyPI version](https://badge.fury.io/py/txCelery.svg)](http://badge.fury.io/py/txCelery)
 
-##Deprecation Notice
+##Fork Notice
 
-txCelery is no longer being developed.  Open an issue if you would like to maintain the project.
+txcelery-py3 is a fork from txCelery.
+
+txCelery (https://github.com/SentimensRG/txCelery) is no longer being developed.
 
 ## Motivation
 
@@ -44,24 +46,24 @@ txCelery's API is so simple it brings tears to our eyes.  There are exactly one 
 
 ###The "one" construct:  wrapping a Celery task
 
-In order to use a Celery task with Twisted, you must wrap your Celery task with a `CeleryClient`-class decorator.  In your `tasks.py` (or wherever you keep your Celery tasks):
+In order to use a Celery task with Twisted, you must wrap your Celery task with a `DeferrableTask`-class decorator.  In your `tasks.py` (or wherever you keep your Celery tasks):
 
 ```python
 from celery import Celery
-from txcelery.defer import CeleryClient
+from txcelery.defer import DeferrableTask
 
 app = Celery('tasks', backend='amqp', broker='amqp://guest@localhost//')
 
 
-@CeleryClient
+@DeferrableTask
 @app.task
 def my_task(*args, **kw):
 	# do something
 ```
 
-There's just one thing to bear in mind:  contrary to the Celery documentation's insistance that `@app.task` be the top-most decorator in your function definition, `CeleryClient` expects to wrap a celery task and will throw a `TypeError` if it receives anything else.
+There's just one thing to bear in mind:  contrary to the Celery documentation's insistance that `@app.task` be the top-most decorator in your function definition, `DeferrableTask` expects to wrap a celery task and will throw a `TypeError` if it receives anything else.
 
-Once you've wrapped your task with the `CeleryClient`-class decorator, you'll find all the usual task methods like `delay`, `apply_async`, `subtask`, `chain`, etc.  The difference is that those which used to return a `celery.result.AsyncResult` will now return a `twisted.internet.defer.Deferred` instance when they are called (ok, actually a subclass of `Deferred`, but more on that in a second).
+Once you've wrapped your task with the `DeferrableTask`-class decorator, you'll find all the usual task methods like `delay`, `apply_async`, `subtask`, `chain`, etc.  The difference is that those which used to return a `celery.result.AsyncResult` will now return a `twisted.internet.defer.Deferred` instance when they are called (ok, actually a subclass of `Deferred`, but more on that in a second).
 
 ###The "one half":  a (Deferred) rose by any other name...
 
@@ -73,7 +75,7 @@ Our subclass is called `DeferredTask`, it lives in `txcelery.defer` and as far a
 
 ###In summary
 
-1.  Wrap a task with a `CeleryClient`
+1.  Wrap a task with a `DeferrableTask`
 2.  Call task methods and obtain a `DeferredTask` instance in lieu of an `AsyncResult`
 3.  Use `DeferredTask` as if it were a regular `Deferred` or a regular `AsyncResult`
 

--- a/pipbuild.sh
+++ b/pipbuild.sh
@@ -25,6 +25,9 @@ fi
 
 echo "Setting version to $VER"
 
+# Update the setup.py
+sed -i "s;^package_version.*=.*;package_version = '${VER}';"  setup.py
+
 # Update the package version
 sed -i "s;.*version.*;__version__ = '${VER}';" txcelery/__init__.py
 

--- a/pipbuild.sh
+++ b/pipbuild.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+PACKAGE="txcelery-py3"
+
+set -o nounset
+set -o errexit
+#set -x
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "There are uncomitted changes, please make sure all changes are comitted" >&2
+    exit 1
+fi
+
+if ! [ -f "setup.py" ]; then
+    echo "setver.sh must be run in the directory where setup.py is" >&2
+    exit 1
+fi
+
+VER="${1:?You must pass a version of the format 0.0.0 as the only argument}"
+
+if git tag | grep -q "${VER}"; then
+    echo "Git tag for version ${VER} already exists." >&2
+    exit 1
+fi
+
+echo "Setting version to $VER"
+
+# Update the package version
+sed -i "s;.*version.*;__version__ = '${VER}';" txcelery/__init__.py
+
+# Upload to test pypi
+if [[ ${VER} == *"dev"* ]]; then
+    python setup.py sdist
+    git reset --hard
+
+else
+    python setup.py sdist upload -r pypitest
+    # Reset the commit, we don't want versions in the commit
+    git commit -a -m "Updated to version ${VER}"
+
+    git tag ${VER}
+    git push
+    git push --tags
+fi
+
+
+
+echo "If you're happy with this you can now run :"
+echo
+echo "python setup.py sdist upload -r pypi"
+echo

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,16 @@
 from setuptools import setup
 
 setup(
-    name='txCelery-syn',
+    name='txcelery-py3',
     version='1.1.0',
     author='Sentimens Research Group, LLC',
     author_email='contact@sentimens.com',
+    maintainer="Synerty Pty Ltd",
+    maintainer_email="contact@synerty.com",
     packages=['txcelery'],
     include_package_data=True,
     install_requires=['Twisted>=11.0.0', 'Celery>=3.0.0', 'setuptools>=0.6'],
-    url='https://github.com/Synerty/txCelery',
+    url='https://github.com/Synerty/txcelery-py3',
     license='MIT',
     description=('Celery for Twisted:  manage Celery tasks from twisted'
                  'using the Deferred API'),

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@
 from setuptools import setup
 
 setup(
-    name='txCelery',
-    version='1.1.0',
-    author='Sentimens Research Group, LLC',
+    name='txcelery-py3',
+    version='1.2.0',
+    author='Original author, Sentimens Research Group, LLC',
     author_email='contact@sentimens.com',
     packages=['txcelery'],
     include_package_data=True,
     install_requires=['Twisted>=11.0.0', 'Celery>=3.0.0', 'setuptools>=0.6'],
-    url='https://github.com/SentimensRG/txCelery',
+    url='https://github.com/Synerty/txcelery-py3',
     license='MIT',
     description=('Celery for Twisted:  manage Celery tasks from twisted'
                  'using the Deferred API'),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 
 package_name = 'txcelery-py3'
-package_version = '1.1.2'
+package_version = '1.1.3'
 
 setup(
     name='txcelery-py3',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
     description=('Celery for Twisted:  manage Celery tasks from twisted'
                  'using the Deferred API'),
     keywords=["celery", "twisted", "deferred", "async", "asynchronous"],
-    long_description=open('README.md').read(),
+    long_description="""Celery for Twisted:
+    Manage Celery tasks from twisted using the Deferred API""",
     classifiers=[
         "Programming Language :: Python :: 3.5",
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
     include_package_data=True,
     install_requires=['Twisted>=11.0.0', 'Celery>=3.0.0', 'setuptools>=0.6'],
     url='https://github.com/Synerty/txcelery-py3',
-    download_url='https://github.com/Synerty/txcelery-py3/tarball/%s' % package_version,
+    download_url=('https://github.com/Synerty/txcelery-py3/tarball/%s'
+                  % txcelery.__version__),
     license='MIT',
     description=('Celery for Twisted:  manage Celery tasks from twisted'
                  'using the Deferred API'),

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-import txcelery
+
+package_name = 'txcelery-py3'
+package_version = '1.1.2'
 
 setup(
     name='txcelery-py3',
-    version=txcelery.__version__,
+    provides='txcelery',
+    version=package_version,
     author='Sentimens Research Group, LLC',
     author_email='contact@sentimens.com',
     maintainer="Synerty Pty Ltd",
@@ -15,7 +18,7 @@ setup(
     install_requires=['Twisted>=11.0.0', 'Celery>=3.0.0', 'setuptools>=0.6'],
     url='https://github.com/Synerty/txcelery-py3',
     download_url=('https://github.com/Synerty/txcelery-py3/tarball/%s'
-                  % txcelery.__version__),
+                  % package_version),
     license='MIT',
     description=('Celery for Twisted:  manage Celery tasks from twisted'
                  'using the Deferred API'),

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 from setuptools import setup
 
+import txcelery
+
 setup(
     name='txcelery-py3',
-    version='1.1.0',
+    version=txcelery.__version__,
     author='Sentimens Research Group, LLC',
     author_email='contact@sentimens.com',
     maintainer="Synerty Pty Ltd",
@@ -12,9 +14,13 @@ setup(
     include_package_data=True,
     install_requires=['Twisted>=11.0.0', 'Celery>=3.0.0', 'setuptools>=0.6'],
     url='https://github.com/Synerty/txcelery-py3',
+    download_url='https://github.com/Synerty/txcelery-py3/tarball/%s' % package_version,
     license='MIT',
     description=('Celery for Twisted:  manage Celery tasks from twisted'
                  'using the Deferred API'),
     keywords=["celery", "twisted", "deferred", "async", "asynchronous"],
-    long_description=open('README.md').read()
+    long_description=open('README.md').read(),
+    classifiers=[
+        "Programming Language :: Python :: 3.5",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@
 from setuptools import setup
 
 setup(
-    name='txCelery',
-    version='1.0.2',
+    name='txCelery-syn',
+    version='1.1.0',
     author='Sentimens Research Group, LLC',
     author_email='contact@sentimens.com',
     packages=['txcelery'],
     include_package_data=True,
     install_requires=['Twisted>=11.0.0', 'Celery>=3.0.0', 'setuptools>=0.6'],
-    url='https://github.com/SentimensRG/txCelery',
+    url='https://github.com/Synerty/txCelery',
     license='MIT',
     description=('Celery for Twisted:  manage Celery tasks from twisted'
                  'using the Deferred API'),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='txCelery',
-    version='1.0.2',
+    version='1.1.0',
     author='Sentimens Research Group, LLC',
     author_email='contact@sentimens.com',
     packages=['txcelery'],

--- a/txcelery/__init__.py
+++ b/txcelery/__init__.py
@@ -3,4 +3,4 @@ from pkg_resources import require
 
 from . import defer
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'

--- a/txcelery/__init__.py
+++ b/txcelery/__init__.py
@@ -3,4 +3,4 @@ from pkg_resources import require
 
 from . import defer
 
-__version__ = "1.1.0"
+__version__ = '1.1.1'

--- a/txcelery/__init__.py
+++ b/txcelery/__init__.py
@@ -3,4 +3,4 @@ from pkg_resources import require
 
 from . import defer
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/txcelery/__init__.py
+++ b/txcelery/__init__.py
@@ -3,4 +3,4 @@ from pkg_resources import require
 
 from . import defer
 
-__version__ = require('txcelery-py3')[0].version
+__version__ = "1.1.0"

--- a/txcelery/__init__.py
+++ b/txcelery/__init__.py
@@ -3,4 +3,4 @@ from pkg_resources import require
 
 from . import defer
 
-__version__ = require('txcelery')[0].version
+__version__ = require('txcelery-py3')[0].version

--- a/txcelery/defer.py
+++ b/txcelery/defer.py
@@ -8,15 +8,14 @@ Module Contents:
     - CeleryClient
 """
 from functools import wraps
-
-from twisted.internet.task import deferLater
-from twisted.python.failure import Failure
 from types import MethodType, FunctionType
 
-from twisted.internet import defer, reactor
 from celery import states
 from celery.local import PromiseProxy
 from celery.result import AsyncResult
+from celery.worker.control import revoke
+from twisted.internet import defer, reactor
+from twisted.python.failure import Failure
 
 
 class DeferredTask(defer.Deferred, object):
@@ -28,34 +27,30 @@ class DeferredTask(defer.Deferred, object):
     oridnary PromiseProxies.
     """
 
-    def __init__(self, async_result, canceller=None):
+    def __init__(self, async_result):
         """Instantiate a `DeferredTask`.  See `help(DeferredTask)` for details
         pertaining to functionality.
 
-        async_result : celery.result.AsyncResult
+        :param async_result : celery.result.AsyncResult
             AsyncResult to be monitored.  When completed or failed, the
             DeferredTask will callback or errback, respectively.
-
-        canceller : None or callable
-            See `help(twisted.internet.defer.Deferred)`
         """
         # Deferred is an old-style class
-        defer.Deferred.__init__(self, canceller=canceller or self._canceller)
+        defer.Deferred.__init__(self, DeferredTask._canceller)
 
         self.task = async_result
         self._monitor_task()
 
     def _canceller(self):
-        # from celery.task.control import revoke
-        # revoke(task_id, terminate=True)
-        self._d.cancel()
+        revoke(self.task.id, terminate=True)
 
     def _monitor_task(self):
         """Wrapper that handles the actual asynchronous monitoring of the task
         state.
+
         """
         if self.task.state in states.UNREADY_STATES:
-            reactor.callLater(0, self._monitor_task)
+            reactor.callLater(1, self._monitor_task)
             return
 
         if self.task.state == 'SUCCESS':
@@ -71,22 +66,22 @@ class DeferredTask(defer.Deferred, object):
             ))
 
 
-class CeleryClient(object):
+class DeferrableTask(object):
     """Decorator class that wraps a celery task such that any methods
     returning an Celery `AsyncResult` instance are wrapped in a
     `DeferredTask` instance.
 
-    Instances of `CeleryClient` expose all methods of the underlying Celery
+    Instances of `DeferrableTask` expose all methods of the underlying Celery
     task.
 
     Usage:
 
-        @CeleryClient
+        @DeferrableTask
         @app.task
         def my_task():
             # ...
 
-    Note:  The `@CeleryClient` decorator must be callsed __after__ the
+    :Note:  The `@DeferrableTask` decorator must be callsed __after__ the
            `@app.task` decorator, meaning that the former must be __above__
            the latter.
     """
@@ -122,4 +117,8 @@ class CeleryClient(object):
         return wrapper
 
 
-__all__ = [CeleryClient, DeferredTask]
+# Backwards compatibility
+class CeleryClient(DeferrableTask):
+    pass
+
+__all__ = [CeleryClient, DeferredTask, DeferrableTask]


### PR DESCRIPTION
Hi
Please accept this pull request, it aims to fix the blocking deferred issue. #1

In addition to this, I've found the @CeleryClient wrapper not to be an intuitive name, I've logged an issue #5 and renamed it to DeferrableTask.

CeleryClient will still work for backwards compatibility.